### PR TITLE
[hotfix] Release 0.78

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ From `state.reported` it exposes:
 - `binary_sensor.<device>_charging` from `robot_sta.value`
 - `switch.<device>_custom_mowing_direction_enabled` to toggle `param_set.enable_adaptive_head`
 - `switch.<device>_rain_perception_enabled` to toggle `rain_switch`
+- `switch.<device>_base_station_mowing_enabled` to toggle Anthbot's nest/base-station mowing mode
+- `switch.<device>_base_station_visual_inspection_enabled` to toggle visual inspection for that mode
+- `number.<device>_base_station_mow_count_setting` for 1x/2x nest mowing passes
+- `number.<device>_base_station_mow_height_setting` for nest mowing height
+- `select.<device>_base_station_visual_inspection_level` for nest visual inspection level (`Low`, `Medium`, `High`)
 
 Entity attributes also include:
 
@@ -59,6 +64,12 @@ Entity attributes also include:
 - `voice_volume`
 - `custom_mowing_direction`
 - `custom_mowing_direction_enabled`
+- `base_station_mowing_enabled`
+- `base_station_mow_count`
+- `base_station_mow_height`
+- `base_station_visual_inspection_enabled`
+- `base_station_visual_inspection_level`
+- `base_station_mowing_active`
 - `rain_continue_time`
 - `voice_status`
 
@@ -144,8 +155,11 @@ The integration also creates control entities on each mower device page:
 - Number controls (sliders): `Mow height`, `Voice volume`
 - Number control (slider): `Custom mowing direction` (0..180)
 - Number control (slider): `Rain continue time` (0..8 hours)
+- Number controls (sliders): `Base station mow count` (1..2), `Base station mow height` (30..70 mm)
+- Select: `Base station visual inspection level` (`Low`, `Medium`, `High`)
 - Switch: `Custom mowing direction enabled`
 - Switch: `Rain perception`
+- Switches: `Base station mowing`, `Base station visual inspection`
 - Sensors: `Zones`, `Auto zones` with zone ids/names summaries
 
 You can trigger/test commands directly from those entities in the device page.

--- a/custom_components/anthbot_genie/__init__.py
+++ b/custom_components/anthbot_genie/__init__.py
@@ -538,11 +538,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 err,
             )
 
+        iot_credentials = None
+        try:
+            iot_credentials = await account_client.async_get_device_iot_credentials(
+                device.serial_number
+            )
+            region_name = iot_credentials.region_name
+            iot_endpoint = iot_credentials.endpoint
+            _LOGGER.debug(
+                "Resolved temporary IoT credentials for %s (%s): region=%s endpoint=%s",
+                device.alias,
+                device.serial_number,
+                region_name,
+                iot_endpoint,
+            )
+        except AnthbotGenieApiError as err:
+            _LOGGER.warning(
+                "Failed to fetch temporary IoT credentials for %s (%s), falling back to static signing: %s",
+                device.alias,
+                device.serial_number,
+                err,
+            )
+
         shadow_client = AnthbotShadowApiClient(
             session=session,
             serial_number=device.serial_number,
             region_name=region_name,
             iot_endpoint=iot_endpoint,
+            iot_credentials=iot_credentials,
         )
         _async_cleanup_legacy_entities(hass, entry, device.serial_number)
         coordinator = AnthbotGenieDataUpdateCoordinator(

--- a/custom_components/anthbot_genie/__init__.py
+++ b/custom_components/anthbot_genie/__init__.py
@@ -45,7 +45,7 @@ from .const import (
 from .coordinator import AnthbotGenieDataUpdateCoordinator
 from .zones import auto_zones, manual_zones
 
-PLATFORMS = ["sensor", "binary_sensor", "button", "number", "switch"]
+PLATFORMS = ["sensor", "binary_sensor", "button", "number", "select", "switch"]
 _LOGGER = logging.getLogger(__name__)
 VALID_MOW_HEIGHTS = list(range(30, 75, 5))
 LEGACY_ENTITY_SUFFIXES: tuple[str, ...] = (

--- a/custom_components/anthbot_genie/api.py
+++ b/custom_components/anthbot_genie/api.py
@@ -9,6 +9,7 @@ import hmac
 import json
 import logging
 import re
+import time
 from typing import Any
 import uuid
 from urllib.parse import parse_qs, quote, urlparse
@@ -465,6 +466,7 @@ class AnthbotShadowApiClient:
         serial_number: str,
         region_name: str | None,
         iot_endpoint: str | None,
+        iot_credentials: AnthbotTemporaryIotCredentials | None = None,
     ) -> None:
         self._session = session
         self._serial_number = serial_number
@@ -472,6 +474,10 @@ class AnthbotShadowApiClient:
             region_name if isinstance(region_name, str) and region_name else None
         )
         self._iot_endpoint = self._normalize_endpoint(iot_endpoint)
+        self._temporary_credentials: AnthbotTemporaryIotCredentials | None = None
+        self._temporary_credentials_expires_at = 0.0
+        if iot_credentials is not None:
+            self.set_temporary_credentials(iot_credentials)
         endpoint_region = self._guess_region_from_endpoint(self._iot_endpoint)
         if (
             self._region_name
@@ -485,6 +491,31 @@ class AnthbotShadowApiClient:
                 endpoint_region,
                 self._iot_endpoint,
             )
+
+    def set_temporary_credentials(
+        self, credentials: AnthbotTemporaryIotCredentials
+    ) -> None:
+        """Store Anthbot-issued temporary AWS IoT credentials."""
+        self._temporary_credentials = credentials
+        self._region_name = credentials.region_name
+        self._iot_endpoint = self._normalize_endpoint(credentials.endpoint)
+        expires_in = credentials.expiration if credentials.expiration else 3600
+        self._temporary_credentials_expires_at = time.monotonic() + max(
+            expires_in - 300, 60
+        )
+
+    async def async_ensure_temporary_credentials(
+        self, account_client: AnthbotCloudApiClient
+    ) -> None:
+        """Refresh temporary AWS IoT credentials before they expire."""
+        if (
+            self._temporary_credentials is not None
+            and time.monotonic() < self._temporary_credentials_expires_at
+        ):
+            return
+        self.set_temporary_credentials(
+            await account_client.async_get_device_iot_credentials(self._serial_number)
+        )
 
     @staticmethod
     def _normalize_endpoint(iot_endpoint: str | None) -> str:
@@ -533,6 +564,8 @@ class AnthbotShadowApiClient:
         return IOT_ENDPOINT_TEMPLATE.format(region=region_name)
 
     def _access_key_id(self) -> str:
+        if self._temporary_credentials is not None:
+            return self._temporary_credentials.access_key_id
         if self._iot_endpoint == CN_NORTHWEST_IOT_ENDPOINT:
             return AWS_ACCESS_KEY_CN_NORTHWEST
         if self.signing_region.startswith("cn"):
@@ -540,11 +573,18 @@ class AnthbotShadowApiClient:
         return AWS_ACCESS_KEY_DEFAULT
 
     def _secret_access_key(self) -> str:
+        if self._temporary_credentials is not None:
+            return self._temporary_credentials.secret_access_key
         if self._iot_endpoint == CN_NORTHWEST_IOT_ENDPOINT:
             return AWS_SECRET_KEY_CN_NORTHWEST
         if self.signing_region.startswith("cn"):
             return AWS_SECRET_KEY_CN
         return AWS_SECRET_KEY_DEFAULT
+
+    def _session_token(self) -> str | None:
+        if self._temporary_credentials is not None:
+            return self._temporary_credentials.session_token
+        return None
 
     @staticmethod
     def _sign(key: bytes, msg: str) -> bytes:
@@ -640,6 +680,29 @@ class AnthbotShadowApiClient:
             "x-amz-content-sha256": payload_hash,
             "x-amz-date": amz_date,
         }
+        headers = {
+            "Accept": "*/*",
+            "Host": self._iot_endpoint,
+            "x-amz-date": amz_date,
+            "x-amz-content-sha256": payload_hash,
+        }
+        session_token = self._session_token()
+        if session_token:
+            invocation_id = str(uuid.uuid4())
+            signed_header_values["amz-sdk-invocation-id"] = invocation_id
+            signed_header_values["amz-sdk-request"] = "attempt=1; max=3"
+            signed_header_values["x-amz-security-token"] = session_token
+            signed_header_values["x-amz-user-agent"] = "aws-sdk-js/3.1025.0"
+            headers["amz-sdk-invocation-id"] = invocation_id
+            headers["amz-sdk-request"] = "attempt=1; max=3"
+            headers["x-amz-security-token"] = session_token
+            headers["x-amz-user-agent"] = "aws-sdk-js/3.1025.0"
+            headers["User-Agent"] = (
+                "aws-sdk-js/3.1025.0 ua/2.1 os/other lang/js "
+                "md/rn api/iot-data-plane#3.1025.0 m/N,E"
+            )
+        else:
+            headers["User-Agent"] = "LdMower/1581 CFNetwork/3860.400.51 Darwin/25.3.0"
         canonical_headers, signed_headers = self._canonical_headers(signed_header_values)
         canonical_request = (
             "GET\n"
@@ -656,14 +719,7 @@ class AnthbotShadowApiClient:
         )
 
         url = f"https://{self._iot_endpoint}{request_uri}?{canonical_query}"
-        headers = {
-            "Accept": "*/*",
-            "Host": self._iot_endpoint,
-            "x-amz-date": amz_date,
-            "x-amz-content-sha256": payload_hash,
-            "Authorization": authorization,
-            "User-Agent": "LdMower/1581 CFNetwork/3860.400.51 Darwin/25.3.0",
-        }
+        headers["Authorization"] = authorization
 
         try:
             async with self._session.get(url, headers=headers, timeout=15) as response:
@@ -734,16 +790,21 @@ class AnthbotShadowApiClient:
             invocation_id = str(uuid.uuid4())
             signed_header_values["amz-sdk-invocation-id"] = invocation_id
             signed_header_values["amz-sdk-request"] = "attempt=1; max=3"
-            signed_header_values["x-amz-user-agent"] = "aws-sdk-js/3.846.0"
+            signed_header_values["x-amz-user-agent"] = "aws-sdk-js/3.1025.0"
             headers["amz-sdk-invocation-id"] = invocation_id
             headers["amz-sdk-request"] = "attempt=1; max=3"
-            headers["x-amz-user-agent"] = "aws-sdk-js/3.846.0"
+            headers["x-amz-user-agent"] = "aws-sdk-js/3.1025.0"
             headers["User-Agent"] = (
-                "aws-sdk-js/3.846.0 ua/2.1 os/other lang/js "
-                "md/rn api/iot-data-plane#3.846.0 m/N,E,e"
+                "aws-sdk-js/3.1025.0 ua/2.1 os/other lang/js "
+                "md/rn api/iot-data-plane#3.1025.0 m/N,E"
             )
         else:
             headers["User-Agent"] = "LdMower/1581 CFNetwork/3860.400.51 Darwin/25.3.0"
+
+        session_token = self._session_token()
+        if session_token:
+            signed_header_values["x-amz-security-token"] = session_token
+            headers["x-amz-security-token"] = session_token
 
         canonical_headers, signed_headers = self._canonical_headers(signed_header_values)
         canonical_uri = (

--- a/custom_components/anthbot_genie/binary_sensor.py
+++ b/custom_components/anthbot_genie/binary_sensor.py
@@ -19,6 +19,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import AnthbotGenieDataUpdateCoordinator
+from .mow_params import (
+    custom_direction_enabled_from_state,
+    nest_mowing_enabled_from_state,
+    nest_visual_inspection_enabled_from_state,
+    nest_visual_inspection_option_from_state,
+    raw_int_value,
+)
 
 
 def _is_connected(data: dict[str, Any]) -> bool:
@@ -43,18 +50,7 @@ def _is_charging(data: dict[str, Any]) -> bool:
 
 
 def _is_custom_mowing_direction_enabled(data: dict[str, Any]) -> bool:
-    param_set = data.get("param_set")
-    if not isinstance(param_set, dict):
-        return False
-    value = param_set.get("enable_adaptive_head")
-    adaptive_enabled = False
-    if isinstance(value, bool):
-        adaptive_enabled = value
-    elif isinstance(value, int):
-        adaptive_enabled = value == 1
-    elif isinstance(value, str):
-        adaptive_enabled = value == "1"
-    return not adaptive_enabled
+    return custom_direction_enabled_from_state(data)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -166,6 +162,15 @@ class AnthbotBinarySensorEntity(
             if isinstance(state.get("param_set"), dict)
             else False
         )
+        base_station_mowing_enabled = nest_mowing_enabled_from_state(state)
+        base_station_mow_count = raw_int_value(state.get("nest_mow_count"))
+        base_station_mow_height = raw_int_value(state.get("nest_cutter_height"))
+        base_station_visual_inspection_enabled = (
+            nest_visual_inspection_enabled_from_state(state)
+        )
+        base_station_visual_inspection_level = (
+            nest_visual_inspection_option_from_state(state)
+        )
         voice_volume = state.get("volume")
         voice_status = (
             state.get("voice_status")
@@ -179,6 +184,13 @@ class AnthbotBinarySensorEntity(
             "mowing_area": mowing_area,
             "custom_mowing_direction": custom_mowing_direction,
             "custom_mowing_direction_enabled": custom_mowing_direction_enabled,
+            "base_station_mowing_enabled": base_station_mowing_enabled,
+            "base_station_mow_count": base_station_mow_count,
+            "base_station_mow_height": base_station_mow_height,
+            "base_station_visual_inspection_enabled": (
+                base_station_visual_inspection_enabled
+            ),
+            "base_station_visual_inspection_level": base_station_visual_inspection_level,
             "voice_volume": voice_volume,
             "voice_status": voice_status,
             "last_service_command": (

--- a/custom_components/anthbot_genie/button.py
+++ b/custom_components/anthbot_genie/button.py
@@ -157,8 +157,8 @@ class AnthbotZoneButtonEntity(
         zone_name = zone.get("name")
         if not isinstance(zone_name, str) or not zone_name.strip():
             zone_name = str(zone_id)
-        prefix = "Zone" if zone_kind == "manual" else "Auto zone"
-        self._attr_name = f"{prefix} {zone_name}"
+        self._attr_translation_key = "zone" if zone_kind == "manual" else "auto_zone"
+        self._attr_translation_placeholders = {"zone_name": zone_name}
         self._attr_unique_id = (
             f"{coordinator.client.serial_number}_{zone_kind}_zone_{zone_id}"
         )

--- a/custom_components/anthbot_genie/button.py
+++ b/custom_components/anthbot_genie/button.py
@@ -157,8 +157,7 @@ class AnthbotZoneButtonEntity(
         zone_name = zone.get("name")
         if not isinstance(zone_name, str) or not zone_name.strip():
             zone_name = str(zone_id)
-        self._attr_translation_key = "zone" if zone_kind == "manual" else "auto_zone"
-        self._attr_translation_placeholders = {"zone_name": zone_name}
+        self._attr_name = zone_name
         self._attr_unique_id = (
             f"{coordinator.client.serial_number}_{zone_kind}_zone_{zone_id}"
         )

--- a/custom_components/anthbot_genie/coordinator.py
+++ b/custom_components/anthbot_genie/coordinator.py
@@ -50,6 +50,7 @@ class AnthbotGenieDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch the latest state from the cloud endpoint."""
         try:
+            await self.client.async_ensure_temporary_credentials(self.account_client)
             property_state = await self.client.async_get_shadow_reported_state()
             try:
                 service_state = await self.client.async_get_service_reported_state()

--- a/custom_components/anthbot_genie/manifest.json
+++ b/custom_components/anthbot_genie/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/vincentjanv/anthbot_genie_ha",
   "iot_class": "cloud_polling",
   "requirements": [],
-  "version": "0.7.7"
+  "version": "0.7.8"
 }

--- a/custom_components/anthbot_genie/manifest.json
+++ b/custom_components/anthbot_genie/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/vincentjanv/anthbot_genie_ha",
   "iot_class": "cloud_polling",
   "requirements": [],
-  "version": "0.7.6"
+  "version": "0.7.7"
 }

--- a/custom_components/anthbot_genie/mow_params.py
+++ b/custom_components/anthbot_genie/mow_params.py
@@ -1,0 +1,122 @@
+"""Helpers for Anthbot mowing parameter state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+NEST_VISUAL_INSPECTION_LEVEL_LOW = "Low"
+NEST_VISUAL_INSPECTION_LEVEL_MEDIUM = "Medium"
+NEST_VISUAL_INSPECTION_LEVEL_HIGH = "High"
+
+NEST_VISUAL_INSPECTION_OPTIONS: tuple[str, ...] = (
+    NEST_VISUAL_INSPECTION_LEVEL_LOW,
+    NEST_VISUAL_INSPECTION_LEVEL_MEDIUM,
+    NEST_VISUAL_INSPECTION_LEVEL_HIGH,
+)
+
+_NEST_VISUAL_INSPECTION_LEVEL_BY_OPTION: dict[str, int] = {
+    NEST_VISUAL_INSPECTION_LEVEL_LOW: 0,
+    NEST_VISUAL_INSPECTION_LEVEL_MEDIUM: 1,
+    NEST_VISUAL_INSPECTION_LEVEL_HIGH: 2,
+}
+_NEST_VISUAL_INSPECTION_OPTION_BY_LEVEL: dict[int, str] = {
+    value: key for key, value in _NEST_VISUAL_INSPECTION_LEVEL_BY_OPTION.items()
+}
+
+
+def coerce_enabled_value(value: object) -> bool:
+    """Map Anthbot integer/bool/string toggles to a Python bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        return lowered in {"1", "true", "on", "enabled", "enable"}
+    return False
+
+
+def raw_int_value(value: object) -> int | None:
+    """Return an integer from common Anthbot shadow payload shapes."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.lstrip("-").isdigit():
+            return int(stripped)
+        return None
+    if isinstance(value, dict):
+        return raw_int_value(value.get("value"))
+    return None
+
+
+def custom_direction_enabled_from_state(data: dict[str, Any]) -> bool:
+    """Map raw enable_adaptive_head value to custom-direction toggle state."""
+    param_set = data.get("param_set")
+    if not isinstance(param_set, dict):
+        return False
+    return not coerce_enabled_value(param_set.get("enable_adaptive_head"))
+
+
+def nest_mowing_enabled_from_state(data: dict[str, Any]) -> bool:
+    """Return whether base-station mowing mode is enabled."""
+    return coerce_enabled_value(data.get("nest_switch"))
+
+
+def nest_visual_inspection_enabled_from_state(data: dict[str, Any]) -> bool:
+    """Return whether base-station visual inspection is enabled."""
+    return coerce_enabled_value(data.get("nest_pobctl_switch"))
+
+
+def nest_visual_inspection_level_from_state(data: dict[str, Any]) -> int | None:
+    """Return the raw base-station visual inspection level."""
+    return raw_int_value(data.get("nest_pobctl_level"))
+
+
+def nest_visual_inspection_option_from_state(data: dict[str, Any]) -> str | None:
+    """Return the labeled base-station visual inspection level."""
+    level = nest_visual_inspection_level_from_state(data)
+    if level is None:
+        return None
+    return _NEST_VISUAL_INSPECTION_OPTION_BY_LEVEL.get(level)
+
+
+def nest_visual_inspection_level_from_option(option: str) -> int:
+    """Map a visual inspection level option back to the raw Anthbot value."""
+    return _NEST_VISUAL_INSPECTION_LEVEL_BY_OPTION[option]
+
+
+def build_nest_mow_params_payload(
+    data: dict[str, Any], **overrides: int | bool
+) -> dict[str, int]:
+    """Build a full nest payload while preserving current values."""
+    cutter_height = raw_int_value(
+        data.get("param_set", {}).get("cutter_height")
+        if isinstance(data.get("param_set"), dict)
+        else None
+    )
+    nest_switch = raw_int_value(data.get("nest_switch"))
+    nest_mow_count = raw_int_value(data.get("nest_mow_count"))
+    nest_cutter_height = raw_int_value(data.get("nest_cutter_height"))
+    nest_pobctl_switch = raw_int_value(data.get("nest_pobctl_switch"))
+    nest_pobctl_level = raw_int_value(data.get("nest_pobctl_level"))
+    payload = {
+        "nest_switch": nest_switch if nest_switch is not None else 0,
+        "nest_mow_count": nest_mow_count if nest_mow_count is not None else 1,
+        "nest_cutter_height": (
+            nest_cutter_height
+            if nest_cutter_height is not None
+            else cutter_height if cutter_height is not None else 35
+        ),
+        "nest_pobctl_switch": (
+            nest_pobctl_switch if nest_pobctl_switch is not None else 0
+        ),
+        "nest_pobctl_level": nest_pobctl_level if nest_pobctl_level is not None else 1,
+    }
+    for key, value in overrides.items():
+        payload[key] = int(value) if isinstance(value, bool) else int(value)
+    return payload

--- a/custom_components/anthbot_genie/number.py
+++ b/custom_components/anthbot_genie/number.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import AnthbotGenieDataUpdateCoordinator
+from .mow_params import build_nest_mow_params_payload
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -89,6 +90,27 @@ NUMBERS: tuple[AnthbotNumberDescription, ...] = (
             if isinstance(data.get("rain_continue_time"), (int, float))
             else None
         ),
+    ),
+    AnthbotNumberDescription(
+        key="base_station_mow_count_setting",
+        translation_key="base_station_mow_count_setting",
+        name="Base station mow count",
+        native_min_value=1,
+        native_max_value=2,
+        native_step=1,
+        mode=NumberMode.SLIDER,
+        getter=lambda data: data.get("nest_mow_count"),
+    ),
+    AnthbotNumberDescription(
+        key="base_station_mow_height_setting",
+        translation_key="base_station_mow_height_setting",
+        name="Base station mow height",
+        native_min_value=30,
+        native_max_value=70,
+        native_step=5,
+        native_unit_of_measurement="mm",
+        mode=NumberMode.SLIDER,
+        getter=lambda data: data.get("nest_cutter_height"),
     ),
 )
 
@@ -181,6 +203,26 @@ class AnthbotNumberEntity(
                     "switch": switch_value,
                     "continue_time": int_value * 3600,
                 },
+            )
+        elif key == "base_station_mow_count_setting":
+            if int_value < 1 or int_value > 2:
+                raise ValueError("Base station mow count must be 1 or 2")
+            await self.coordinator.client.async_publish_service_command(
+                cmd="set_mow_params",
+                data=build_nest_mow_params_payload(
+                    self.coordinator.reported_state,
+                    nest_mow_count=int_value,
+                ),
+            )
+        elif key == "base_station_mow_height_setting":
+            if int_value < 30 or int_value > 70 or int_value % 5 != 0:
+                raise ValueError("Base station mow height must be 30..70 in 5 mm steps")
+            await self.coordinator.client.async_publish_service_command(
+                cmd="set_mow_params",
+                data=build_nest_mow_params_payload(
+                    self.coordinator.reported_state,
+                    nest_cutter_height=int_value,
+                ),
             )
         await self.coordinator.client.async_request_all_properties()
         await asyncio.sleep(1)

--- a/custom_components/anthbot_genie/select.py
+++ b/custom_components/anthbot_genie/select.py
@@ -1,0 +1,97 @@
+"""Select platform for Anthbot Genie settings."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import AnthbotGenieDataUpdateCoordinator
+from .mow_params import (
+    NEST_VISUAL_INSPECTION_OPTIONS,
+    build_nest_mow_params_payload,
+    nest_visual_inspection_level_from_option,
+    nest_visual_inspection_option_from_state,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class AnthbotSelectDescription(SelectEntityDescription):
+    """Describes an Anthbot select setting."""
+
+
+SELECTS: tuple[AnthbotSelectDescription, ...] = (
+    AnthbotSelectDescription(
+        key="base_station_visual_inspection_level",
+        translation_key="base_station_visual_inspection_level",
+        name="Base station visual inspection level",
+        options=list(NEST_VISUAL_INSPECTION_OPTIONS),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Anthbot select entities from config entry."""
+    coordinators: list[AnthbotGenieDataUpdateCoordinator] = hass.data[DOMAIN][
+        entry.entry_id
+    ]
+    async_add_entities(
+        AnthbotSelectEntity(coordinator, description)
+        for coordinator in coordinators
+        for description in SELECTS
+    )
+
+
+class AnthbotSelectEntity(
+    CoordinatorEntity[AnthbotGenieDataUpdateCoordinator], SelectEntity
+):
+    """Anthbot select entity."""
+
+    entity_description: AnthbotSelectDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: AnthbotGenieDataUpdateCoordinator,
+        description: AnthbotSelectDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.client.serial_number}_{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.client.serial_number)},
+            manufacturer="Anthbot",
+            model=coordinator.device.model,
+            name=coordinator.device.alias,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected option."""
+        return nest_visual_inspection_option_from_state(self.coordinator.reported_state)
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the selected option."""
+        await self.coordinator.client.async_publish_service_command(
+            cmd="set_mow_params",
+            data=build_nest_mow_params_payload(
+                self.coordinator.reported_state,
+                nest_pobctl_level=nest_visual_inspection_level_from_option(option),
+            ),
+        )
+        await self.coordinator.client.async_request_all_properties()
+        await asyncio.sleep(1)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/anthbot_genie/sensor.py
+++ b/custom_components/anthbot_genie/sensor.py
@@ -21,23 +21,19 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import AnthbotGenieDataUpdateCoordinator
+from .mow_params import (
+    custom_direction_enabled_from_state,
+    nest_mowing_enabled_from_state,
+    nest_visual_inspection_enabled_from_state,
+    nest_visual_inspection_option_from_state,
+    raw_int_value,
+)
 from .zones import active_manual_zone_ids, auto_zones, manual_zones
 
 
 def _is_custom_mowing_direction_enabled(data: dict[str, Any]) -> bool:
     """Map raw enable_adaptive_head value to custom-direction state."""
-    param_set = data.get("param_set")
-    if not isinstance(param_set, dict):
-        return False
-    value = param_set.get("enable_adaptive_head")
-    adaptive_enabled = False
-    if isinstance(value, bool):
-        adaptive_enabled = value
-    elif isinstance(value, int):
-        adaptive_enabled = value == 1
-    elif isinstance(value, str):
-        adaptive_enabled = value == "1"
-    return not adaptive_enabled
+    return custom_direction_enabled_from_state(data)
 
 
 _ROBOT_STATUS_BY_CODE: tuple[str, ...] = (
@@ -341,6 +337,15 @@ class AnthbotSensorEntity(
             if isinstance(state.get("param_set"), dict)
             else False
         )
+        base_station_mowing_enabled = nest_mowing_enabled_from_state(state)
+        base_station_mow_count = raw_int_value(state.get("nest_mow_count"))
+        base_station_mow_height = raw_int_value(state.get("nest_cutter_height"))
+        base_station_visual_inspection_enabled = (
+            nest_visual_inspection_enabled_from_state(state)
+        )
+        base_station_visual_inspection_level = (
+            nest_visual_inspection_option_from_state(state)
+        )
         voice_volume = state.get("volume")
         voice_status = (
             state.get("voice_status")
@@ -350,6 +355,7 @@ class AnthbotSensorEntity(
         rain_continue_time = state.get("rain_continue_time")
         mower_status = _general_mower_status(state)
         robot_status_raw = _raw_robot_status(state)
+        base_station_mowing_active = robot_status_raw == "nestmowing"
         attributes = {
             "serial_number": self.coordinator.client.serial_number,
             "mower_status": mower_status,
@@ -359,6 +365,14 @@ class AnthbotSensorEntity(
             "mowing_area": mowing_area,
             "custom_mowing_direction": custom_mowing_direction,
             "custom_mowing_direction_enabled": custom_mowing_direction_enabled,
+            "base_station_mowing_enabled": base_station_mowing_enabled,
+            "base_station_mow_count": base_station_mow_count,
+            "base_station_mow_height": base_station_mow_height,
+            "base_station_visual_inspection_enabled": (
+                base_station_visual_inspection_enabled
+            ),
+            "base_station_visual_inspection_level": base_station_visual_inspection_level,
+            "base_station_mowing_active": base_station_mowing_active,
             "voice_volume": voice_volume,
             "voice_status": voice_status,
             "rain_continue_time": rain_continue_time,

--- a/custom_components/anthbot_genie/strings.json
+++ b/custom_components/anthbot_genie/strings.json
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Rain continue time"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Base station mow count"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Base station mow height"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Base station visual inspection level"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Rain perception"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Base station mowing"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Base station visual inspection"
       }
     }
   }

--- a/custom_components/anthbot_genie/strings.json
+++ b/custom_components/anthbot_genie/strings.json
@@ -76,6 +76,12 @@
       },
       "return_to_dock": {
         "name": "Return to dock"
+      },
+      "zone": {
+        "name": "Zone {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Auto zone {zone_name}"
       }
     },
     "number": {

--- a/custom_components/anthbot_genie/switch.py
+++ b/custom_components/anthbot_genie/switch.py
@@ -15,23 +15,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api import AnthbotGenieApiError
 from .const import DOMAIN
 from .coordinator import AnthbotGenieDataUpdateCoordinator
-
-
-def _coerce_enabled_value(value: object) -> bool:
-    """Map Anthbot integer/bool/string toggles to a Python bool."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        return value == 1
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        return lowered in {"1", "true", "on", "enabled", "enable"}
-    return False
-
-
-def _is_custom_direction_enabled(value: object) -> bool:
-    """Map raw enable_adaptive_head value to custom-direction toggle state."""
-    return not _coerce_enabled_value(value)
+from .mow_params import (
+    build_nest_mow_params_payload,
+    coerce_enabled_value,
+    custom_direction_enabled_from_state,
+    nest_mowing_enabled_from_state,
+    nest_visual_inspection_enabled_from_state,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -49,6 +39,16 @@ SWITCHES: tuple[AnthbotSwitchDescription, ...] = (
         key="rain_perception_enabled",
         translation_key="rain_perception_enabled",
         name="Rain perception",
+    ),
+    AnthbotSwitchDescription(
+        key="base_station_mowing_enabled",
+        translation_key="base_station_mowing_enabled",
+        name="Base station mowing",
+    ),
+    AnthbotSwitchDescription(
+        key="base_station_visual_inspection_enabled",
+        translation_key="base_station_visual_inspection_enabled",
+        name="Base station visual inspection",
     ),
 )
 
@@ -99,12 +99,12 @@ class AnthbotSwitchEntity(
         """Return current switch value."""
         state = self.coordinator.reported_state
         if self.entity_description.key == "rain_perception_enabled":
-            return _coerce_enabled_value(state.get("rain_switch"))
-
-        param_set = state.get("param_set")
-        if not isinstance(param_set, dict):
-            return False
-        return _is_custom_direction_enabled(param_set.get("enable_adaptive_head"))
+            return coerce_enabled_value(state.get("rain_switch"))
+        if self.entity_description.key == "base_station_mowing_enabled":
+            return nest_mowing_enabled_from_state(state)
+        if self.entity_description.key == "base_station_visual_inspection_enabled":
+            return nest_visual_inspection_enabled_from_state(state)
+        return custom_direction_enabled_from_state(state)
 
     async def _async_set_custom_direction_enabled(self, enabled: bool) -> None:
         """Set custom mowing direction toggle."""
@@ -152,10 +152,44 @@ class AnthbotSwitchEntity(
                 "Rain perception command was accepted but the reported state did not change"
             )
 
+    async def _async_set_base_station_mowing_enabled(self, enabled: bool) -> None:
+        """Set base-station mowing mode."""
+        await self.coordinator.client.async_publish_service_command(
+            cmd="set_mow_params",
+            data=build_nest_mow_params_payload(
+                self.coordinator.reported_state,
+                nest_switch=1 if enabled else 0,
+            ),
+        )
+        await self.coordinator.client.async_request_all_properties()
+        await asyncio.sleep(1)
+        await self.coordinator.async_request_refresh()
+
+    async def _async_set_base_station_visual_inspection_enabled(
+        self, enabled: bool
+    ) -> None:
+        """Set base-station visual inspection toggle."""
+        await self.coordinator.client.async_publish_service_command(
+            cmd="set_mow_params",
+            data=build_nest_mow_params_payload(
+                self.coordinator.reported_state,
+                nest_pobctl_switch=1 if enabled else 0,
+            ),
+        )
+        await self.coordinator.client.async_request_all_properties()
+        await asyncio.sleep(1)
+        await self.coordinator.async_request_refresh()
+
     async def async_turn_on(self, **kwargs) -> None:
         """Turn switch on."""
         if self.entity_description.key == "rain_perception_enabled":
             await self._async_set_rain_perception_enabled(True)
+            return
+        if self.entity_description.key == "base_station_mowing_enabled":
+            await self._async_set_base_station_mowing_enabled(True)
+            return
+        if self.entity_description.key == "base_station_visual_inspection_enabled":
+            await self._async_set_base_station_visual_inspection_enabled(True)
             return
         await self._async_set_custom_direction_enabled(True)
 
@@ -163,5 +197,11 @@ class AnthbotSwitchEntity(
         """Turn switch off."""
         if self.entity_description.key == "rain_perception_enabled":
             await self._async_set_rain_perception_enabled(False)
+            return
+        if self.entity_description.key == "base_station_mowing_enabled":
+            await self._async_set_base_station_mowing_enabled(False)
+            return
+        if self.entity_description.key == "base_station_visual_inspection_enabled":
+            await self._async_set_base_station_visual_inspection_enabled(False)
             return
         await self._async_set_custom_direction_enabled(False)

--- a/custom_components/anthbot_genie/translations/de.json
+++ b/custom_components/anthbot_genie/translations/de.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Anthbot-Kontoerkennung und Cloud-Shadow-Abfrage konfigurieren.",
+        "data": {
+          "name": "Name",
+          "username": "E-Mail / Benutzername",
+          "password": "Passwort",
+          "api_host": "Anthbot-API-Host",
+          "area_code": "Land",
+          "scan_interval": "Abfrageintervall (Sekunden)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Dieses Anthbot-Konto ist bereits konfiguriert."
+    },
+    "error": {
+      "cannot_connect": "Verbindung oder Anmeldung an der Anthbot-Cloud fehlgeschlagen.",
+      "no_devices": "Anmeldung erfolgreich, aber in diesem Konto wurden keine Anthbot-Geräte gefunden.",
+      "unknown": "Unerwarteter Fehler."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "Mäherstatus"
+      },
+      "cutting_height": {
+        "name": "Schnitthöhe"
+      },
+      "voice_volume": {
+        "name": "Lautstärke"
+      },
+      "mowing_time": {
+        "name": "Mähzeit (Sitzung)"
+      },
+      "mowing_area": {
+        "name": "Mähfläche (Sitzung)"
+      },
+      "custom_mowing_direction": {
+        "name": "Benutzerdefinierte Mährichtung"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Benutzerdefinierte Mährichtung aktiviert"
+      },
+      "battery_level": {
+        "name": "Akkustand"
+      },
+      "zones": {
+        "name": "Zonen"
+      },
+      "auto_zones": {
+        "name": "Auto-Zonen"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Verbindung"
+      },
+      "charging": {
+        "name": "Ladevorgang"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Benutzerdefinierte Mährichtung aktiviert"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Komplettes Mähen starten"
+      },
+      "stop_mow": {
+        "name": "Mähen stoppen"
+      },
+      "return_to_dock": {
+        "name": "Zur Ladestation zurückkehren"
+      },
+      "zone": {
+        "name": "Zone {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Auto-Zone {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Schnitthöhe"
+      },
+      "voice_volume_setting": {
+        "name": "Lautstärke"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Benutzerdefinierte Mährichtung"
+      },
+      "rain_continue_time_setting": {
+        "name": "Regen-Wartezeit"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Benutzerdefinierte Mährichtung aktiviert"
+      },
+      "rain_perception_enabled": {
+        "name": "Regenerkennung"
+      }
+    }
+  }
+}

--- a/custom_components/anthbot_genie/translations/de.json
+++ b/custom_components/anthbot_genie/translations/de.json
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Regen-Wartezeit"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Mähdurchgänge an der Ladestation"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Schnitthöhe an der Ladestation"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Sichtprüfung an der Ladestation"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Regenerkennung"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Mähen an der Ladestation"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Sichtprüfung an der Ladestation"
       }
     }
   }

--- a/custom_components/anthbot_genie/translations/es.json
+++ b/custom_components/anthbot_genie/translations/es.json
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Tiempo de espera por lluvia"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Pasadas junto a la base"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Altura de corte junto a la base"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Nivel de inspección visual junto a la base"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Detección de lluvia"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Corte junto a la base"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Inspección visual junto a la base"
       }
     }
   }

--- a/custom_components/anthbot_genie/translations/es.json
+++ b/custom_components/anthbot_genie/translations/es.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Configura la detección de cuenta Anthbot y la consulta del cloud shadow.",
+        "data": {
+          "name": "Nombre",
+          "username": "Correo electrónico / nombre de usuario",
+          "password": "Contraseña",
+          "api_host": "Host de la API de Anthbot",
+          "area_code": "País",
+          "scan_interval": "Intervalo de sondeo (segundos)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Esta cuenta de Anthbot ya está configurada."
+    },
+    "error": {
+      "cannot_connect": "No se pudo conectar o autenticar con la nube de Anthbot.",
+      "no_devices": "El inicio de sesión fue correcto, pero no se encontraron dispositivos Anthbot en esta cuenta.",
+      "unknown": "Error inesperado."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "Estado del cortacésped"
+      },
+      "cutting_height": {
+        "name": "Altura de corte"
+      },
+      "voice_volume": {
+        "name": "Volumen de voz"
+      },
+      "mowing_time": {
+        "name": "Tiempo de corte (sesión)"
+      },
+      "mowing_area": {
+        "name": "Área cortada (sesión)"
+      },
+      "custom_mowing_direction": {
+        "name": "Dirección de corte personalizada"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Dirección de corte personalizada activada"
+      },
+      "battery_level": {
+        "name": "Nivel de batería"
+      },
+      "zones": {
+        "name": "Zonas"
+      },
+      "auto_zones": {
+        "name": "Zonas automáticas"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Conexión"
+      },
+      "charging": {
+        "name": "Carga"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Dirección de corte personalizada activada"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Iniciar corte completo"
+      },
+      "stop_mow": {
+        "name": "Detener corte"
+      },
+      "return_to_dock": {
+        "name": "Volver a la base"
+      },
+      "zone": {
+        "name": "Zona {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Zona automática {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Altura de corte"
+      },
+      "voice_volume_setting": {
+        "name": "Volumen de voz"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Dirección de corte personalizada"
+      },
+      "rain_continue_time_setting": {
+        "name": "Tiempo de espera por lluvia"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Dirección de corte personalizada activada"
+      },
+      "rain_perception_enabled": {
+        "name": "Detección de lluvia"
+      }
+    }
+  }
+}

--- a/custom_components/anthbot_genie/translations/fr.json
+++ b/custom_components/anthbot_genie/translations/fr.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Configurer la découverte du compte Anthbot et l'interrogation du cloud shadow.",
+        "data": {
+          "name": "Nom",
+          "username": "E-mail / nom d'utilisateur",
+          "password": "Mot de passe",
+          "api_host": "Hôte API Anthbot",
+          "area_code": "Pays",
+          "scan_interval": "Intervalle d'interrogation (secondes)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Ce compte Anthbot est déjà configuré."
+    },
+    "error": {
+      "cannot_connect": "Impossible de se connecter ou de s'authentifier auprès du cloud Anthbot.",
+      "no_devices": "Connexion réussie, mais aucun appareil Anthbot n'a été trouvé dans ce compte.",
+      "unknown": "Erreur inattendue."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "État de la tondeuse"
+      },
+      "cutting_height": {
+        "name": "Hauteur de coupe"
+      },
+      "voice_volume": {
+        "name": "Volume vocal"
+      },
+      "mowing_time": {
+        "name": "Temps de tonte (session)"
+      },
+      "mowing_area": {
+        "name": "Surface tondue (session)"
+      },
+      "custom_mowing_direction": {
+        "name": "Direction de tonte personnalisée"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Direction de tonte personnalisée activée"
+      },
+      "battery_level": {
+        "name": "Niveau de batterie"
+      },
+      "zones": {
+        "name": "Zones"
+      },
+      "auto_zones": {
+        "name": "Zones automatiques"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Connexion"
+      },
+      "charging": {
+        "name": "Charge"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Direction de tonte personnalisée activée"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Démarrer la tonte complète"
+      },
+      "stop_mow": {
+        "name": "Arrêter la tonte"
+      },
+      "return_to_dock": {
+        "name": "Retour à la station"
+      },
+      "zone": {
+        "name": "Zone {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Zone automatique {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Hauteur de coupe"
+      },
+      "voice_volume_setting": {
+        "name": "Volume vocal"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Direction de tonte personnalisée"
+      },
+      "rain_continue_time_setting": {
+        "name": "Temps d'attente pluie"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Direction de tonte personnalisée activée"
+      },
+      "rain_perception_enabled": {
+        "name": "Détection de pluie"
+      }
+    }
+  }
+}

--- a/custom_components/anthbot_genie/translations/fr.json
+++ b/custom_components/anthbot_genie/translations/fr.json
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Temps d'attente pluie"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Passes près de la station"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Hauteur de coupe près de la station"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Niveau d'inspection visuelle près de la station"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Détection de pluie"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Tonte près de la station"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Inspection visuelle près de la station"
       }
     }
   }

--- a/custom_components/anthbot_genie/translations/it.json
+++ b/custom_components/anthbot_genie/translations/it.json
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Tempo di attesa pioggia"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Passaggi vicino alla base"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Altezza di taglio vicino alla base"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Livello di ispezione visiva vicino alla base"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Rilevamento pioggia"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Taglio vicino alla base"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Ispezione visiva vicino alla base"
       }
     }
   }

--- a/custom_components/anthbot_genie/translations/it.json
+++ b/custom_components/anthbot_genie/translations/it.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Configura il rilevamento dell'account Anthbot e il polling del cloud shadow.",
+        "data": {
+          "name": "Nome",
+          "username": "E-mail / nome utente",
+          "password": "Password",
+          "api_host": "Host API Anthbot",
+          "area_code": "Paese",
+          "scan_interval": "Intervallo di polling (secondi)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Questo account Anthbot è già configurato."
+    },
+    "error": {
+      "cannot_connect": "Impossibile connettersi o autenticarsi con il cloud Anthbot.",
+      "no_devices": "Accesso riuscito, ma non sono stati trovati dispositivi Anthbot in questo account.",
+      "unknown": "Errore imprevisto."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "Stato del rasaerba"
+      },
+      "cutting_height": {
+        "name": "Altezza di taglio"
+      },
+      "voice_volume": {
+        "name": "Volume voce"
+      },
+      "mowing_time": {
+        "name": "Tempo di taglio (sessione)"
+      },
+      "mowing_area": {
+        "name": "Area tagliata (sessione)"
+      },
+      "custom_mowing_direction": {
+        "name": "Direzione di taglio personalizzata"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Direzione di taglio personalizzata attiva"
+      },
+      "battery_level": {
+        "name": "Livello batteria"
+      },
+      "zones": {
+        "name": "Zone"
+      },
+      "auto_zones": {
+        "name": "Zone automatiche"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Connessione"
+      },
+      "charging": {
+        "name": "Ricarica"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Direzione di taglio personalizzata attiva"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Avvia taglio completo"
+      },
+      "stop_mow": {
+        "name": "Arresta taglio"
+      },
+      "return_to_dock": {
+        "name": "Rientra alla base"
+      },
+      "zone": {
+        "name": "Zona {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Zona automatica {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Altezza di taglio"
+      },
+      "voice_volume_setting": {
+        "name": "Volume voce"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Direzione di taglio personalizzata"
+      },
+      "rain_continue_time_setting": {
+        "name": "Tempo di attesa pioggia"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Direzione di taglio personalizzata attiva"
+      },
+      "rain_perception_enabled": {
+        "name": "Rilevamento pioggia"
+      }
+    }
+  }
+}

--- a/custom_components/anthbot_genie/translations/nl.json
+++ b/custom_components/anthbot_genie/translations/nl.json
@@ -86,7 +86,7 @@
     },
     "number": {
       "mow_height_setting": {
-        "name": "Maa hoogte"
+        "name": "Maai hoogte"
       },
       "voice_volume_setting": {
         "name": "Stemvolume"
@@ -96,6 +96,17 @@
       },
       "rain_continue_time_setting": {
         "name": "Regen wachttijd"
+      },
+      "base_station_mow_count_setting": {
+        "name": "Maaibeurten bij laadstation"
+      },
+      "base_station_mow_height_setting": {
+        "name": "Maai hoogte bij laadstation"
+      }
+    },
+    "select": {
+      "base_station_visual_inspection_level": {
+        "name": "Visueel inspectieniveau bij laadstation"
       }
     },
     "switch": {
@@ -104,6 +115,12 @@
       },
       "rain_perception_enabled": {
         "name": "Regendetectie"
+      },
+      "base_station_mowing_enabled": {
+        "name": "Maaien bij laadstation"
+      },
+      "base_station_visual_inspection_enabled": {
+        "name": "Visuele inspectie bij laadstation"
       }
     }
   }

--- a/custom_components/anthbot_genie/translations/nl.json
+++ b/custom_components/anthbot_genie/translations/nl.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Anthbot-accountdetectie en cloud shadow polling configureren.",
+        "data": {
+          "name": "Naam",
+          "username": "E-mail / gebruikersnaam",
+          "password": "Wachtwoord",
+          "api_host": "Anthbot API-host",
+          "area_code": "Land",
+          "scan_interval": "Polling-interval (seconden)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Dit Anthbot-account is al geconfigureerd."
+    },
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken of aanmelden bij de Anthbot-cloud.",
+      "no_devices": "Aanmelden gelukt, maar er zijn geen Anthbot-apparaten gevonden in dit account.",
+      "unknown": "Onverwachte fout."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "Maaierstatus"
+      },
+      "cutting_height": {
+        "name": "Maai hoogte"
+      },
+      "voice_volume": {
+        "name": "Stemvolume"
+      },
+      "mowing_time": {
+        "name": "Maaiduurtijd (sessie)"
+      },
+      "mowing_area": {
+        "name": "Maaigebied (sessie)"
+      },
+      "custom_mowing_direction": {
+        "name": "Aangepaste maairichting"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Aangepaste maairichting ingeschakeld"
+      },
+      "battery_level": {
+        "name": "Batterijniveau"
+      },
+      "zones": {
+        "name": "Zones"
+      },
+      "auto_zones": {
+        "name": "Autozones"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Verbinding"
+      },
+      "charging": {
+        "name": "Opladen"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Aangepaste maairichting ingeschakeld"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Volledig maaien starten"
+      },
+      "stop_mow": {
+        "name": "Maaien stoppen"
+      },
+      "return_to_dock": {
+        "name": "Terug naar laadstation"
+      },
+      "zone": {
+        "name": "Zone {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Autozone {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Maa hoogte"
+      },
+      "voice_volume_setting": {
+        "name": "Stemvolume"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Aangepaste maairichting"
+      },
+      "rain_continue_time_setting": {
+        "name": "Regen wachttijd"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Aangepaste maairichting ingeschakeld"
+      },
+      "rain_perception_enabled": {
+        "name": "Regendetectie"
+      }
+    }
+  }
+}

--- a/custom_components/anthbot_genie/translations/pl.json
+++ b/custom_components/anthbot_genie/translations/pl.json
@@ -1,0 +1,110 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anthbot Genie",
+        "description": "Skonfiguruj Anthbot konto i pobieranie danych.",
+        "data": {
+          "name": "Nazwa",
+          "username": "Email / login",
+          "password": "Hasło",
+          "api_host": "Anthbot API host",
+          "area_code": "Kraj",
+          "scan_interval": "Interwał pobierania danych (sekundy)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Konto Anthbot jest już skonfigurowane."
+    },
+    "error": {
+      "cannot_connect": "Nie można połączyć się lub zalogować do chmury Anthbot.",
+      "no_devices": "Zalogowano do chmury Anthbot ale nie znaleziono żadnych urządzeń przypisanych do konta.",
+      "unknown": "Nieoczekiwany błąd."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "mower_status": {
+        "name": "Status kosiarki"
+      },
+      "cutting_height": {
+        "name": "Wysokość koszenia"
+      },
+      "voice_volume": {
+        "name": "Głośność komunikatów"
+      },
+      "mowing_time": {
+        "name": "Czas koszenia (sesja)"
+      },
+      "mowing_area": {
+        "name": "Obszar koszenia (sesja)"
+      },
+      "custom_mowing_direction": {
+        "name": "Niestandardowy kierunek koszenia"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Status niestandardowego kierunku koszenia"
+      },
+      "battery_level": {
+        "name": "Poziom naładowania baterii"
+      },
+      "zones": {
+        "name": "Strefy"
+      },
+      "auto_zones": {
+        "name": "Strefy automatyczne"
+      }
+    },
+    "binary_sensor": {
+      "connection": {
+        "name": "Połączenie"
+      },
+      "charging": {
+        "name": "Ładowanie"
+      },
+      "custom_mowing_direction_enabled": {
+        "name": "Status niestandardowego kierunku koszenia"
+      }
+    },
+    "button": {
+      "start_full_mow": {
+        "name": "Rozpocznij pełne koszenie"
+      },
+      "stop_mow": {
+        "name": "Zatrzymaj koszenie"
+      },
+      "return_to_dock": {
+        "name": "Powrót do stacji"
+      },
+      "zone": {
+        "name": "Strefa {zone_name}"
+      },
+      "auto_zone": {
+        "name": "Strefa automatyczna {zone_name}"
+      }
+    },
+    "number": {
+      "mow_height_setting": {
+        "name": "Wysokość koszenia"
+      },
+      "voice_volume_setting": {
+        "name": "Głośność komunikatów"
+      },
+      "custom_mowing_direction_setting": {
+        "name": "Niestandardowy kierunek koszenia"
+      },
+      "rain_continue_time_setting": {
+        "name": "Czas opóźnienia po deszczu"
+      }
+    },
+    "switch": {
+      "custom_mowing_direction_enabled": {
+        "name": "Status niestandardowego kierunku koszenia"
+      },
+      "rain_perception_enabled": {
+        "name": "Wykrywanie deszczu"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release summary for v0.7.8:

  ## What's Changed

  - Fixed cloud access after Anthbot moved IoT shadow access to temporary STS credentials.
  - Added base-station / nest mowing controls, including enable toggle, mow count, cutting height, visual inspection toggle, and visual inspection level.
  - Added a standard Home Assistant `lawn_mower` entity with start, pause/stop, and dock actions.
  - Added translations for Dutch, German, French, Spanish, Italian, and Polish.
  - Fixed dynamic zone button names so they use the actual zone names.

  ## Community Contributions

  - Thanks to Denis Kot / @DenisBY for the `lawn_mower` platform support.
  - Thanks to Tomasz Terlecki / @tazmanska for Polish translations.
