### PR TITLE
Add Anthbot Genie 1000 to supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a custom integration for Anthbot robotic mowers:
 
 ## What it does now
 
-This integration supports the Anthbot Genie 600, M5, and M9 models. It auto-discovers all account-bound mowers via:
+This integration supports the Anthbot Genie 600, Genie 1000, M5, and M9 models. It auto-discovers all account-bound mowers via:
 
 - `GET https://api.anthbot.com/api/v1/device/bind/list`
 


### PR DESCRIPTION
The Anthbot Genie 1000 works with this integration without any code changes.
It reports the same `service`/`property` shadow shape as the Genie 600, so it
is already handled by the existing (non M5/M9) code path.

Verified on real hardware (Genie 1000, firmware 1.18.18):
- Auto-discovery and config flow succeed; the mower and its entities are created.
- Polling returns valid state: battery level, mower status, zones, cutting
  height, voice volume, session mowing time/area, etc.
- Command publishing works: starting a zone mow (`custom_area_mow_start`) and
  returning to the dock (`charge_start`) both round-tripped successfully and the
  mower responded physically.

This PR only adds "Genie 1000" to the supported-models line in the README;
there are no code changes.
