### PR TITLE
Fix incorrect shadow key paths for several sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ From `state.reported` it exposes:
 - `sensor.<device>_custom_mowing_direction` from `param_set.mow_head`
 - `sensor.<device>_custom_mowing_direction_enabled` from `param_set.enable_adaptive_head` (mapped to enabled/disabled)
 - `sensor.<device>_mode` from `mode.value` (M5/M9)
-- `sensor.<device>_error_code` from `error.value` (M5/M9)
-- `sensor.<device>_ip_address` from `net_config.ip` (M5/M9)
-- `sensor.<device>_wifi_ssid` from `net_config.ssid` (M5/M9)
-- `sensor.<device>_rtk_state` from `rtk.state` (M5/M9)
-- `sensor.<device>_map_area` from `map.map_area` (M5/M9)
-- `sensor.<device>_mapping_task_state` from `mapping_task.state` (M5/M9)
+- `sensor.<device>_error_code` from `err_code`
+- `sensor.<device>_ip_address` from `sta_ip_addr`
+- `sensor.<device>_wifi_ssid` from `sta_ssid`
+- `sensor.<device>_rtk_state` from `rtk_state`
+- `sensor.<device>_map_area` from `map_area`
+- `sensor.<device>_mapping_task_state` from `map_sta.value`
 - `sensor.<device>_zones` for discovered manual zones
 - `sensor.<device>_auto_zones` for discovered auto-zones
 - `binary_sensor.<device>_connection` from `online`

--- a/custom_components/anthbot_genie/binary_sensor.py
+++ b/custom_components/anthbot_genie/binary_sensor.py
@@ -78,48 +78,28 @@ def _is_custom_mowing_direction_enabled(data: dict[str, Any]) -> bool:
 
 
 def _is_rain_sensor_active(data: dict[str, Any]) -> bool:
-    """Check if rain sensor is active."""
-    device_config = data.get("device_config")
-    if isinstance(device_config, dict):
-        value = device_config.get("rain_switch")
-        return value in (1, "1", True, "true")
-    return False
+    """Check if rain perception is active."""
+    return data.get("rain_switch") in (1, "1", True, "true")
 
 
 def _is_camera_active(data: dict[str, Any]) -> bool:
     """Check if camera is active."""
-    device_config = data.get("device_config")
-    if isinstance(device_config, dict):
-        value = device_config.get("camera_switch")
-        return value in (1, "1", True, "true")
-    return False
+    return data.get("camera_switch") in (1, "1", True, "true")
 
 
 def _is_anti_theft_active(data: dict[str, Any]) -> bool:
-    """Check if anti-theft protection is active."""
-    device_config = data.get("device_config")
-    if isinstance(device_config, dict):
-        value = device_config.get("anti_loss_switch")
-        return value in (1, "1", True, "true")
-    return False
+    """Check if anti-theft (anti-loss) protection is active."""
+    return data.get("anti_loss_switch") in (1, "1", True, "true")
 
 
 def _is_wifi_connected(data: dict[str, Any]) -> bool:
     """Check if WiFi is connected."""
-    net_state = data.get("net_state")
-    if isinstance(net_state, dict):
-        value = net_state.get("wifi_state")
-        return value in (1, "1", True, "true")
-    return False
+    return data.get("wifi_state") in (1, "1", True, "true")
 
 
 def _is_4g_connected(data: dict[str, Any]) -> bool:
     """Check if 4G is connected."""
-    net_state = data.get("net_state")
-    if isinstance(net_state, dict):
-        value = net_state.get("4g_state")
-        return value in (1, "1", True, "true")
-    return False
+    return data.get("4g_state") in (1, "1", True, "true")
 
 
 def _is_adaptive_head_enabled(data: dict[str, Any]) -> bool:
@@ -202,11 +182,11 @@ def _binary_sensor_path_for_description(description: AnthbotBinarySensorDescript
     """Return the data path for a binary sensor description, if it has one."""
     # Map binary sensor keys to their data paths for conditional creation
     path_map: dict[str, list[str]] = {
-        "rain_sensor": ["device_config", "rain_switch"],
-        "camera": ["device_config", "camera_switch"],
-        "anti_theft": ["device_config", "anti_loss_switch"],
-        "wifi_connected": ["net_state", "wifi_state"],
-        "mobile_connected": ["net_state", "4g_state"],
+        "rain_sensor": ["rain_switch"],
+        "camera": ["camera_switch"],
+        "anti_theft": ["anti_loss_switch"],
+        "wifi_connected": ["wifi_state"],
+        "mobile_connected": ["4g_state"],
         "adaptive_head_enabled": ["param_set", "enable_adaptive_head"],
     }
     return path_map.get(description.key)

--- a/custom_components/anthbot_genie/sensor.py
+++ b/custom_components/anthbot_genie/sensor.py
@@ -296,31 +296,19 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
         key="error_code",
         translation_key="error_code",
         name="Error code",
-        value_fn=lambda data: (
-            data.get("error", {}).get("value")
-            if isinstance(data.get("error"), dict)
-            else None
-        ),
+        value_fn=lambda data: data.get("err_code"),
     ),
     AnthbotSensorDescription(
         key="ip_address",
         translation_key="ip_address",
         name="IP address",
-        value_fn=lambda data: (
-            data.get("net_config", {}).get("ip")
-            if isinstance(data.get("net_config"), dict)
-            else None
-        ),
+        value_fn=lambda data: data.get("sta_ip_addr"),
     ),
     AnthbotSensorDescription(
         key="wifi_ssid",
         translation_key="wifi_ssid",
         name="WiFi SSID",
-        value_fn=lambda data: (
-            data.get("net_config", {}).get("ssid")
-            if isinstance(data.get("net_config"), dict)
-            else None
-        ),
+        value_fn=lambda data: data.get("sta_ssid"),
     ),
     AnthbotSensorDescription(
         key="mowing_area_total",
@@ -353,9 +341,7 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
         translation_key="rtk_state",
         name="RTK state",
         value_fn=lambda data: (
-            str(data.get("rtk", {}).get("state"))
-            if isinstance(data.get("rtk"), dict) and data.get("rtk", {}).get("state") is not None
-            else None
+            str(data.get("rtk_state")) if data.get("rtk_state") is not None else None
         ),
     ),
     AnthbotSensorDescription(
@@ -365,19 +351,15 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         device_class=SensorDeviceClass.AREA,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: (
-            data.get("map", {}).get("map_area")
-            if isinstance(data.get("map"), dict)
-            else None
-        ),
+        value_fn=lambda data: data.get("map_area"),
     ),
     AnthbotSensorDescription(
         key="mapping_task_state",
         translation_key="mapping_task_state",
         name="Mapping task state",
         value_fn=lambda data: (
-            str(data.get("mapping_task", {}).get("state"))
-            if isinstance(data.get("mapping_task"), dict) and data.get("mapping_task", {}).get("state") is not None
+            data.get("map_sta", {}).get("value")
+            if isinstance(data.get("map_sta"), dict)
             else None
         ),
     ),
@@ -398,18 +380,14 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
         key="sim_id",
         translation_key="sim_id",
         name="SIM ID",
-        value_fn=lambda data: (
-            data.get("net_config", {}).get("4g_ccid")
-            if isinstance(data.get("net_config"), dict)
-            else None
-        ),
+        value_fn=lambda data: data.get("4g_ccid"),
     ),
     AnthbotSensorDescription(
         key="ota_status",
         translation_key="ota_status",
         name="OTA status",
         value_fn=lambda data: (
-            data.get("ota_status", {}).get("states")
+            data.get("ota_status", {}).get("ota_state")
             if isinstance(data.get("ota_status"), dict)
             else None
         ),
@@ -421,7 +399,7 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: (
-            data.get("ota_status", {}).get("progress")
+            data.get("ota_status", {}).get("ota_progress")
             if isinstance(data.get("ota_status"), dict)
             else None
         ),
@@ -455,20 +433,20 @@ def _sensor_path_for_description(description: AnthbotSensorDescription) -> list[
     # Map sensor keys to their data paths for conditional creation
     path_map: dict[str, list[str]] = {
         "volume": ["device_config", "volume"],
-        "sim_id": ["net_config", "4g_ccid"],
-        "ota_status": ["ota_status", "states"],
-        "ota_progress": ["ota_status", "progress"],
+        "sim_id": ["4g_ccid"],
+        "ota_status": ["ota_status", "ota_state"],
+        "ota_progress": ["ota_status", "ota_progress"],
         "firmware_version": ["fw_version", "system_version"],
         "mow_count": ["param_set", "mow_count"],
         "mode": ["mode", "value"],
-        "error_code": ["error", "value"],
-        "ip_address": ["net_config", "ip"],
-        "wifi_ssid": ["net_config", "ssid"],
+        "error_code": ["err_code"],
+        "ip_address": ["sta_ip_addr"],
+        "wifi_ssid": ["sta_ssid"],
         "mowing_area_total": ["mowing_area", "value"],
         "mowing_time_total": ["mowing_time", "value"],
-        "rtk_state": ["rtk", "state"],
-        "map_area": ["map", "map_area"],
-        "mapping_task_state": ["mapping_task", "state"],
+        "rtk_state": ["rtk_state"],
+        "map_area": ["map_area"],
+        "mapping_task_state": ["map_sta", "value"],
     }
     return path_map.get(description.key)
 
@@ -616,34 +594,14 @@ class AnthbotSensorEntity(
                 if isinstance(state.get("mode"), dict)
                 else None
             ),
-            "error_code": (
-                state.get("error", {}).get("value")
-                if isinstance(state.get("error"), dict)
-                else None
-            ),
-            "ip_address": (
-                state.get("net_config", {}).get("ip")
-                if isinstance(state.get("net_config"), dict)
-                else None
-            ),
-            "wifi_ssid": (
-                state.get("net_config", {}).get("ssid")
-                if isinstance(state.get("net_config"), dict)
-                else None
-            ),
-            "rtk_state": (
-                state.get("rtk", {}).get("state")
-                if isinstance(state.get("rtk"), dict)
-                else None
-            ),
-            "map_area": (
-                state.get("map", {}).get("map_area")
-                if isinstance(state.get("map"), dict)
-                else None
-            ),
+            "error_code": state.get("err_code"),
+            "ip_address": state.get("sta_ip_addr"),
+            "wifi_ssid": state.get("sta_ssid"),
+            "rtk_state": state.get("rtk_state"),
+            "map_area": state.get("map_area"),
             "mapping_task_state": (
-                state.get("mapping_task", {}).get("state")
-                if isinstance(state.get("mapping_task"), dict)
+                state.get("map_sta", {}).get("value")
+                if isinstance(state.get("map_sta"), dict)
                 else None
             ),
         }


### PR DESCRIPTION
Several sensor and binary_sensor entities read shadow keys that do not exist
in the device `state.reported`. Because the conditional-creation path map used
the same wrong keys, the affected entities were never created at all (and their
attribute reads were always None).

Corrected paths:

| Entity | Was | Now |
|---|---|---|
| sensor rtk_state | `rtk.state` | `rtk_state` |
| sensor map_area | `map.map_area` | `map_area` |
| sensor error_code | `error.value` | `err_code` |
| sensor mapping_task_state | `mapping_task.state` | `map_sta.value` |
| sensor ip_address | `net_config.ip` | `sta_ip_addr` |
| sensor wifi_ssid | `net_config.ssid` | `sta_ssid` |
| sensor sim_id | `net_config.4g_ccid` | `4g_ccid` |
| sensor ota_status | `ota_status.states` | `ota_status.ota_state` |
| sensor ota_progress | `ota_status.progress` | `ota_status.ota_progress` |
| binary_sensor rain_sensor | `device_config.rain_switch` | `rain_switch` |
| binary_sensor camera | `device_config.camera_switch` | `camera_switch` |
| binary_sensor anti_theft | `device_config.anti_loss_switch` | `anti_loss_switch` |
| binary_sensor wifi_connected | `net_state.wifi_state` | `wifi_state` |
| binary_sensor mobile_connected | `net_state.4g_state` | `4g_state` |

The same corrections are applied to the conditional-creation path maps, to the
duplicated reads in `sensor.py` `extra_state_attributes`, and to the affected
source-key references in the README.

**Why:** these fixes (in particular `map_area`) are needed to drive a companion
Lovelace card, https://github.com/jnaatanen/pd-anthbot-genie-card, which reads
these entities; today they simply don't exist.

**Testing:** verified against live shadow data on real **Anthbot Genie 600 and
Genie 1000** mowers — all listed entities are now created and report correct
values. I do **not** have M5/M9 hardware, so these models should be verified by
someone who does (the corrected keys are top-level scalars in the shadow on the
600/1000, but I can't confirm the M5/M9 payloads).

No functional change to already-working entities; this only repoints keys that
were previously dead.
