### PR TITLE
Add live position sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ From `state.reported` it exposes:
 - `sensor.<device>_mapping_task_state` from `mapping_task.state` (M5/M9)
 - `sensor.<device>_zones` for discovered manual zones
 - `sensor.<device>_auto_zones` for discovered auto-zones
+- `sensor.<device>_position` from `pose` (live position; `x`/`y` attributes are in millimetres, in the same coordinate frame as zone `vertexs`, plus a `heading` attribute in degrees)
 - `binary_sensor.<device>_connection` from `online`
 - `binary_sensor.<device>_charging` from `robot_sta.value` or `mode.value`
 - `switch.<device>_custom_mowing_direction_enabled` to toggle `param_set.enable_adaptive_head`

--- a/custom_components/anthbot_genie/sensor.py
+++ b/custom_components/anthbot_genie/sensor.py
@@ -168,6 +168,35 @@ def _general_mower_status(data: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _pose(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the live pose dict (x/y in millimetres, same frame as zone vertexs)."""
+    pose = data.get("pose")
+    return pose if isinstance(pose, dict) else None
+
+
+def _position_summary(data: dict[str, Any]) -> str | None:
+    """Return the live position as an 'x, y' string in millimetres."""
+    pose = _pose(data)
+    if pose is None:
+        return None
+    x = pose.get("x")
+    y = pose.get("y")
+    if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+        return None
+    return f"{x}, {y}"
+
+
+def _heading_degrees(data: dict[str, Any]) -> float | None:
+    """Return mower heading in degrees [0, 360) derived from pose.yaw."""
+    pose = _pose(data)
+    if pose is None:
+        return None
+    yaw = pose.get("yaw")
+    if not isinstance(yaw, (int, float)):
+        return None
+    return round(yaw % 360, 1)
+
+
 @dataclass(frozen=True, kw_only=True)
 class AnthbotSensorDescription(SensorEntityDescription):
     """Describes an Anthbot sensor entity."""
@@ -447,6 +476,13 @@ SENSORS: tuple[AnthbotSensorDescription, ...] = (
             else None
         ),
     ),
+    AnthbotSensorDescription(
+        key="position",
+        translation_key="position",
+        name="Position",
+        icon="mdi:crosshairs-gps",
+        value_fn=_position_summary,
+    ),
 )
 
 
@@ -460,6 +496,7 @@ def _sensor_path_for_description(description: AnthbotSensorDescription) -> list[
         "ota_progress": ["ota_status", "progress"],
         "firmware_version": ["fw_version", "system_version"],
         "mow_count": ["param_set", "mow_count"],
+        "position": ["pose", "x"],
         "mode": ["mode", "value"],
         "error_code": ["error", "value"],
         "ip_address": ["net_config", "ip"],
@@ -672,4 +709,10 @@ class AnthbotSensorEntity(
                 for zone in auto_zone_list
                 if isinstance((zone_name := zone.get("name")), str) and zone_name
             ]
+        if self.entity_description.key == "position":
+            pose = _pose(state) or {}
+            attributes["x"] = pose.get("x")
+            attributes["y"] = pose.get("y")
+            attributes["heading"] = _heading_degrees(state)
+            attributes["yaw_raw"] = pose.get("yaw")
         return attributes

--- a/custom_components/anthbot_genie/strings.json
+++ b/custom_components/anthbot_genie/strings.json
@@ -99,6 +99,9 @@
       },
       "mow_count": {
         "name": "Mow count"
+      },
+      "position": {
+        "name": "Position"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
Expose the top-level `pose` object from the device shadow as a new
`sensor.<device>_position` entity.

- State: the `"x, y"` coordinate.
- Attributes: `x`, `y` (millimetres, the **same coordinate frame as the zone
  `vertexs`**), `heading` (degrees, derived from `pose.yaw`) and `yaw_raw`.
- Created only when `pose` is present.

**Why:** this enables a companion Lovelace card,
https://github.com/jnaatanen/pd-anthbot-genie-card, to draw the mower's live
position on the same map as the zones, using one shared transform.

**Testing:** verified on real **Anthbot Genie 600 and Genie 1000** mowers. The
millimetre scale was cross-checked against `anti_loss_pose.pose2d` (metres) and
matches. Not tested on M5/M9 — please verify there.

Note: `heading` is computed as `yaw % 360`; the exact north reference has not
been confirmed by a controlled drive test yet, so treat `heading` as
best-effort (the `x`/`y` position is solid).
