### PR TITLE
Keep the real-time telemetry stream alive on each poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Then it polls the AWS IoT device shadow endpoint per discovered `sn` using autom
 
 - `GET https://<iot_endpoint>/things/<sn>/shadow?name=property`
 
+On every poll the integration also sends an `app_state` keep-alive command. The
+mower only streams live telemetry (such as live position and path) to the cloud
+shadow while a client signals an active app session, and stops roughly 60 seconds
+after the last signal. Re-sending it each poll keeps that data fresh in Home
+Assistant without the phone app being open.
+
 It also fetches the mower area definition file from Anthbot cloud to discover:
 
 - manual zones

--- a/custom_components/anthbot_genie/coordinator.py
+++ b/custom_components/anthbot_genie/coordinator.py
@@ -51,6 +51,18 @@ class AnthbotGenieDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch the latest state from the cloud endpoint."""
         try:
             await self.client.async_ensure_temporary_credentials(self.account_client)
+            # Keep the device's real-time stream alive. The mower only streams
+            # live telemetry (pose/curpath) to the cloud shadow while a client
+            # signals an active app session; it stops roughly 60 s after the
+            # last signal. Re-sending it every poll keeps pose/curpath fresh in
+            # HA without the phone app open. Best-effort: never fail the update
+            # if the keep-alive command does not go through.
+            try:
+                await self.client.async_publish_service_command(
+                    cmd="app_state", data=1
+                )
+            except AnthbotGenieApiError as err:
+                self.logger.debug("Real-time keep-alive (app_state) failed: %s", err)
             property_state = await self.client.async_get_shadow_reported_state()
             try:
                 service_state = await self.client.async_get_service_reported_state()


### PR DESCRIPTION
The mower only streams live telemetry (the `pose` object and the `curpath` path
blob) to the cloud shadow while a client signals an active app session via
`app_state=1`, and it stops roughly 60 seconds after the last signal. Without
this, `pose`/`curpath` freeze at a stale near-origin default, so live position
and path never update in Home Assistant unless the official phone app happens to
be open.

This sends `app_state=1` (best-effort) at the start of every coordinator poll,
so the device keeps streaming while Home Assistant is polling. With the default
30 s scan interval this stays well inside the ~60 s stream timeout, keeping the
data continuously fresh.

**Why:** this is what makes the live-position / coverage data actually usable,
and it feeds a companion Lovelace card
(https://github.com/jnaatanen/pd-anthbot-genie-card).

**Testing:** verified on real **Anthbot Genie 600 and Genie 1000** mowers with
the phone app CLOSED — `pose` was frozen beforehand and tracks the mower live
afterward (moved several metres between 30 s polls). Not tested on M5/M9; please
verify there.

Best-effort: if the keep-alive command fails it is logged at debug level and the
shadow read proceeds normally.
